### PR TITLE
Update to 2.5.0

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,16 +1,15 @@
 numpy:
-  - 1.16    # [not (arm64 or aarch64 or s390x)]
-  - 1.19    # [aarch64 or s390x]
-  - 1.16    # [not (aarch64 or s390x)]
-  - 1.19    # [aarch64 or s390x]
-  - 1.19
-  - 1.21
+- 1.16 # [not (aarch64 or s390x or arm64)]
+- 1.16 # [not (aarch64 or s390x or arm64)]
+- 1.19 # [aarch64 or s390x]
+- 1.19 # [aarch64 or s390x or arm64]
+- 1.19
+- 1.21
 python:
-  - 3.7      # [not arm64]
-  - 3.8
-  - 3.9
-  - "3.10"
+- 3.7  # [not arm64]
+- 3.8
+- 3.9
+- "3.10"
 zip_keys:
-  -
-    - python
-    - numpy
+- numpy
+- python

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,16 @@
+numpy:
+  - 1.16    # [not (arm64 or aarch64 or s390x)]
+  - 1.19    # [aarch64 or s390x]
+  - 1.16    # [not (aarch64 or s390x)]
+  - 1.19    # [aarch64 or s390x]
+  - 1.19
+  - 1.21
+python:
+  - 3.7      # [not arm64]
+  - 3.8
+  - 3.9
+  - "3.10"
+zip_keys:
+  -
+    - python
+    - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - pip
     - wheel
     - setuptools
+    # See our custom cbc.yaml for modified pinnnigs
     - numpy
     - scikit-learn >=0.20.0
     - scipy >=1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "category_encoders" %}
-{% set version = "2.2.2" %}
+{% set version = "2.5.0" %}
 
 package:
   name: {{ name }}
@@ -7,36 +7,38 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 79651dc3e8cd6749bc5d404c49a79e93469016d106736326842305e076136cb0
+    sha256: 64dc68cd30dea32a390b3eed880f6e365635118c916b082dde99b76741155c15
     folder: dist
   - url: https://github.com/scikit-learn-contrib/{{ name }}/archive/{{ version }}.tar.gz
-    sha256: b8fa5f2c2f3294ed7847e9c5486566604a6a321308dfb5377440a7ca2a9a5b1f
+    sha256: ff72d21ddf62d829f43375c67ea4934c82947f9a0c5cbf9114838624db941420
     folder: src
 
 build:
-  noarch: python
+  # noarch: python
   number: 0
   script:
-    - cd dist && {{ PYTHON }} -m pip install -vvv .
+    - cd dist && {{ PYTHON }} -m pip install --no-deps -vvv .
 
 requirements:
   host:
-    - numpy >=1.14.0
-    - pandas >=0.21.1
-    - patsy >=0.5.1
+    - python
     - pip
-    - python >=3.5
+    - wheel
+    - setuptools
+    - numpy >=1.16
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0
-  run:
-    - numpy >=1.14.0
     - pandas >=0.21.1
     - patsy >=0.5.1
-    - python >=3.5
+  run:
+    - numpy >=1.16
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0
+    - pandas >=0.21.1
+    - patsy >=0.5.1
+    - python
 
 test:
   source_files:
@@ -64,19 +66,14 @@ about:
     into numeric with different techniques. While ordinal, one-hot, and hashing
     encoders have similar equivalents in the existing scikit-learn version, the
     transformers in this library all share a few useful properties:
-
     - First-class support for pandas dataframes as an input (and optionally as
       output)
-
     - Can explicitly configure which columns in the data are encoded by name or
       index, or infer non-numeric columns regardless of input type
-
     - Can drop any columns with very low variance based on training set
       optionally
-
     - Portability: train a transformer on data, pickle it, reuse it later and
       get the same thing out.
-
     - Full compatibility with sklearn pipelines, input an array-like dataset
       like any other transformer
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - patsy >=0.5.1
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   # noarch: python
   number: 0
-  skip: true  # [py<37 or py>310]
+  skip: true  # [py<37]
   script:
     - {{ PYTHON }} -m pip install --no-deps -vvv .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "category_encoders" %}
 {% set version = "2.5.0" %}
+{% set sha256 = "ff72d21ddf62d829f43375c67ea4934c82947f9a0c5cbf9114838624db941420" %}
 
 package:
   name: {{ name }}
@@ -7,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/scikit-learn-contrib/{{ name }}/archive/{{ version }}.tar.gz
-    sha256: ff72d21ddf62d829f43375c67ea4934c82947f9a0c5cbf9114838624db941420
+    sha256: {{ sha256 }}
 
 build:
   # noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,18 +6,15 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 64dc68cd30dea32a390b3eed880f6e365635118c916b082dde99b76741155c15
-    folder: dist
   - url: https://github.com/scikit-learn-contrib/{{ name }}/archive/{{ version }}.tar.gz
     sha256: ff72d21ddf62d829f43375c67ea4934c82947f9a0c5cbf9114838624db941420
-    folder: src
 
 build:
   # noarch: python
   number: 0
+  skip: true  # [py<37 or py>310]
   script:
-    - cd dist && {{ PYTHON }} -m pip install --no-deps -vvv .
+    - {{ PYTHON }} -m pip install --no-deps -vvv .
 
 requirements:
   host:
@@ -25,24 +22,26 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - numpy >=1.16
+    - numpy >=1.14
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0
-    - pandas >=0.21.1
+    - pandas >=1.0.5
     - patsy >=0.5.1
+    - unittest2
   run:
-    - numpy >=1.16
+    - python
+    - numpy >=1.14
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0
-    - pandas >=0.21.1
+    - pandas >=1.0.5
     - patsy >=0.5.1
-    - python
+    - unittest2
 
 test:
   source_files:
-    - src/tests
+    - tests
   requires:
     - cython
     - pip
@@ -52,13 +51,13 @@ test:
     - category_encoders
   commands:
     - python -m pip check
-    - cd src && pytest -vv --cov category_encoders -k "not (pandas_index or truncated_index)"
+    - pytest -vv --cov category_encoders -k "not (pandas_index or truncated_index)"
 
 about:
   home: https://github.com/scikit-learn-contrib/categorical_encoding
   license: BSD-3-Clause
   license_family: BSD
-  license_file: dist/LICENSE.md
+  license_file: LICENSE.md
   summary: A collection sklearn transformers to encode categorical variables as numeric
   doc_url: https://contrib.scikit-learn.org/categorical-encoding
   description: |-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - numpy >=1.14
+    - numpy
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0
@@ -32,7 +32,7 @@ requirements:
     - unittest2
   run:
     - python
-    - numpy >=1.14
+    - {{ pin_compatible('numpy') }}
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - patsy >=0.5.1
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - scikit-learn >=0.20.0
     - scipy >=1.0.0
     - statsmodels >=0.9.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,15 +43,13 @@ test:
   source_files:
     - tests
   requires:
-    - cython
     - pip
     - pytest
-    - pytest-cov
   imports:
     - category_encoders
   commands:
     - python -m pip check
-    - pytest -vv --cov category_encoders -k "not (pandas_index or truncated_index)"
+    - pytest -vv -k "not (pandas_index or truncated_index)"
 
 about:
   home: https://github.com/scikit-learn-contrib/categorical_encoding

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - statsmodels >=0.9.0
     - pandas >=1.0.5
     - patsy >=0.5.1
-    - unittest2
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -38,7 +37,6 @@ requirements:
     - statsmodels >=0.9.0
     - pandas >=1.0.5
     - patsy >=0.5.1
-    - unittest2
 
 test:
   source_files:


### PR DESCRIPTION
This is actually a significant update. The conda-forge recipe actually pulls the PyPi package for _installation_, but the GitHub source repository for testing. Looking at their CI, there is absolutely nothing special about their PyPi build. So it makes sense to eliminate the PyPi download and work with GitHub exclusively.

Note that a significant test suite is being executed here, the same one used in conda-forge, so we still have confidence we're building the right thing

- Eliminate dual pypi/github download
- Update version and sha256
- Update dependency pins
- Remove noarch
- Cean up metadata